### PR TITLE
Mentioning the SoftID wiki page

### DIFF
--- a/softid.tex
+++ b/softid.tex
@@ -89,6 +89,10 @@ protocols, we believe similar practices should be implemented where, as
 with most VOEvent transports, communication mechanisms are not built on
 top of HTTP.
 
+To facilitate per-client analyses or similar use cases, adopters of this
+note are requested to give the identification strings for their software
+on the SoftID page in the IVOA
+wiki\footnote{\url{https://wiki.ivoa.net/twiki/bin/view/IVOA/SoftID}}.
 
 \subsection{Use Cases}
 


### PR DESCRIPTION
Mark has set up a wiki page listing well-known identification strings.  This PR mentions that in the note.